### PR TITLE
FinishedPromise.install() replaces native Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ describe('FinishedPromise', () => {
   })
 })
 ```
+
+## async / await
+
+Overriding `global.Promise` has no effect on `async` functions - they will use
+the native v8 `Promise` regardless.
+
+To circumvent this limitation we can transpile the source code prior to running
+it. Babel can do this, although rather slowly, which would defeat the purpose
+of this library - fast tests!
+
+Instead we can use [async-to-gen](https://github.com/leebyron/async-to-gen) which
+is actually very fast. See `./mocha` for an example.

--- a/index.js
+++ b/index.js
@@ -100,4 +100,14 @@ FinishedPromise.reject = function(error) {
   })
 }
 
+const nativePromise = Promise
+
+FinishedPromise.install = function() {
+  Promise = FinishedPromise
+}
+
+FinishedPromise.uninstall = function() {
+  Promise = nativePromise
+}
+
 module.exports = FinishedPromise

--- a/mocha
+++ b/mocha
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+node_modules/.bin/async-node node_modules/.bin/_mocha "$@"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "Synchronous implementation of Promise for use in tests",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "./mocha"
   },
   "author": "Josh Chisholm <joshuachisholm@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "async-to-gen": "^1.3.3",
     "mocha": "^3.2.0"
   },
   "repository": {

--- a/test/_globalPromiseTest.js
+++ b/test/_globalPromiseTest.js
@@ -24,7 +24,7 @@ describe('Promise', () => {
     assert.equal(result, 123)
   })
 
-  it('is replaced with FinishedPromise in async functions (failing)', () => {
+  it('is replaced with FinishedPromise in async functions', () => {
     let result
 
     async function f1(v) {

--- a/test/_globalPromiseTest.js
+++ b/test/_globalPromiseTest.js
@@ -1,0 +1,20 @@
+const assert = require('assert')
+const FinishedPromise = require('..')
+
+describe('Promise', () => {
+  before(() => {
+    FinishedPromise.install()
+  })
+
+  after(() => {
+    FinishedPromise.uninstall()
+  })
+
+  it('is replaced with FinishedPromise', () => {
+    let result
+    Promise.resolve(123).then(resolved => {
+      result = resolved
+    })
+    assert.equal(result, 123)
+  })
+})

--- a/test/_globalPromiseTest.js
+++ b/test/_globalPromiseTest.js
@@ -2,12 +2,17 @@ const assert = require('assert')
 const FinishedPromise = require('..')
 
 describe('Promise', () => {
+  const nativeThen = Promise.prototype.then
   before(() => {
+    Promise.prototype.then = function () {
+      throw new Error("native Promise still alive and kicking")
+    }
     FinishedPromise.install()
   })
 
   after(() => {
     FinishedPromise.uninstall()
+    Promise.prototype.then = nativeThen
   })
 
   it('is replaced with FinishedPromise', () => {
@@ -15,6 +20,16 @@ describe('Promise', () => {
     Promise.resolve(123).then(resolved => {
       result = resolved
     })
+    assert.equal(result, 123)
+  })
+
+  it('is replaced with FinishedPromise in async functions (failing)', () => {
+    let result
+
+    async function f(resolved) {
+      result = resolved
+    }
+    Promise.resolve(123).then(f)
     assert.equal(result, 123)
   })
 })

--- a/test/_globalPromiseTest.js
+++ b/test/_globalPromiseTest.js
@@ -2,34 +2,39 @@ const assert = require('assert')
 const FinishedPromise = require('..')
 
 describe('Promise', () => {
-  const nativeThen = Promise.prototype.then
   before(() => {
-    Promise.prototype.then = function () {
-      throw new Error("native Promise still alive and kicking")
-    }
     FinishedPromise.install()
   })
 
   after(() => {
     FinishedPromise.uninstall()
-    Promise.prototype.then = nativeThen
   })
 
   it('is replaced with FinishedPromise', () => {
     let result
-    Promise.resolve(123).then(resolved => {
-      result = resolved
-    })
+
+    function f1(v) {
+      return Promise.resolve(v)
+    }
+    function f2(v) {
+      result = v
+    }
+
+    Promise.resolve(123).then(f1).then(f2)
     assert.equal(result, 123)
   })
 
   it('is replaced with FinishedPromise in async functions (failing)', () => {
     let result
 
-    async function f(resolved) {
-      result = resolved
+    async function f1(v) {
+      return v
     }
-    Promise.resolve(123).then(f)
+    async function f2(v) {
+      result = v
+    }
+
+    Promise.resolve(123).then(f1).then(f2)
     assert.equal(result, 123)
   })
 })


### PR DESCRIPTION
This is an attempt to provide a simple mechanism to replace the native `Promise` with `FinishedPromise`.

The rationale behind this is to be able to force 3rd party libraries using `Promise` to use `FinishedPromise` in tests.

I haven't tested this with any 3rd party libraries, so this PR is just to start the discussion. Do you think this would work?